### PR TITLE
Fix auto-sync stale latest overwrite

### DIFF
--- a/examples/json-auto-sync/auto-sync.yml
+++ b/examples/json-auto-sync/auto-sync.yml
@@ -66,12 +66,15 @@ jobs:
           echo "  GITHUB_REPO: $GITHUB_REPO"
           echo ""
           echo "🚀 Running sync script..."
+          # Use local-output mode and let this workflow commit the generated files.
+          # Do not let sync.py publish latest.json via the GitHub API here: the
+          # later archive/commit step stages the checkout copy of latest.json,
+          # so API-publishing first can be overwritten by a stale local file.
           python sync.py \
             --athlete-id "$ATHLETE_ID" \
             --intervals-key "$INTERVALS_KEY" \
-            --github-token "$GITHUB_TOKEN" \
-            --github-repo "$GITHUB_REPO" \
-            --days 7 || {
+            --days 7 \
+            --output latest.json || {
               echo "❌ Sync script failed with exit code $?"
               exit 1
             }


### PR DESCRIPTION
## Summary
- Switch the GitHub Actions auto-sync example to `sync.py --output latest.json`
- Let the workflow commit generated JSON files as the single writer
- Avoid API-publishing `latest.json` first and then overwriting it with the checkout copy during the archive commit step

## Why
The previous workflow mixed two write paths:
1. `sync.py` published fresh `latest.json` through the GitHub Contents API.
2. The later archive step staged/committed the local checkout copy of `latest.json`, which `sync.py` had not updated in GitHub mode.

That can re-push a stale local file after the script log says “Data published”.

## Verification
- `ruby -e "require \"yaml\"; YAML.load_file(\"examples/json-auto-sync/auto-sync.yml\")"`
- `git diff --check`